### PR TITLE
Author data

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -11,6 +11,11 @@ theme = "book"
   url = "https://klezmerarchive.org"
   weight = 10
 
+[taxonomies]
+	author = "authors"
+	tag = "tags"
+	category = "categories"
+
 [params]
   # (Optional, default light) Sets color theme: light, dark or auto.
   # Theme 'auto' switches between dark and light modes based on browser/os preferences

--- a/content/posts/announcing-the-klezmer-archive-project-blog.md
+++ b/content/posts/announcing-the-klezmer-archive-project-blog.md
@@ -1,7 +1,8 @@
 ---
-title: " Announcing the Klezmer Archive Project Blog!"
+title: Announcing the Klezmer Archive Project Blog!
 date: 2021-09-30T23:28:13.836Z
 description: Welcome to the Klezmer Archive Project Blog
+image: /images/uploads/berebotski.png
 tags:
   - news
 categories:
@@ -10,7 +11,3 @@ categories:
 Howdy friends, 
 
 Welcome to the new blog for the Klezmer Archive Project. We are excited to start sharing some of the work we have been doing with the project and will use this space to keep members of our community and other intrested folks up to date on what we're up to!
-
-
-
-![](/images/uploads/berebotski.png)

--- a/content/posts/welcome-to-the-klezmer-archive-project-blog-1.md
+++ b/content/posts/welcome-to-the-klezmer-archive-project-blog-1.md
@@ -6,15 +6,13 @@ description: "In our first post we’d like to briefly describe how The Klezmer
   (KMDMP) relate to each other while being distinct projects with different
   design, audience and objectives. "
 image: /images/uploads/ka-lib-card-logo-left-rule-only.png
+authors:
+  - Christina Crowder
 tags:
   - news
 categories:
   - Klezmer
 ---
-\
-Welcome to the Klezmer Archive Project Blog!! 
-
-By Christina Crowder, 25 May, 2022
 
 In our first post we’d like to briefly describe how The Klezmer Archive Project and the Kiselgof-Makonovetsky Digital Manuscript Project (KMDMP) relate to each other while being distinct projects with different design, audience and objectives. The KMDMP corpus is being used as a “test corpus” for the Klezmer Archive Project, and the crowdsourcing and community-building aspects of the project are informing Klezmer Archive research in the areas of user experience, data ingestion, and ontology building among others. Both projects were startup initiatives of the Klezmer Institute that began in 2020. The Klezmer Archive Project has been funded by a Phase I NEH Digital Humanities Advancement Grant from 2021-2022, while KMDMP is supported solely by individual donations.    
 

--- a/layouts/partials/docs/post-meta.html
+++ b/layouts/partials/docs/post-meta.html
@@ -1,3 +1,13 @@
+<section class="authors">
+{{ range .Param "authors" }}
+	{{ $name := . }}
+	{{ $path := printf "/%s/%s" "authors" ($name | urlize) }}
+  <a href={{ $path }}>
+    <h5>{{ $name }}</h5>
+  </a>
+{{ end }}
+</section>
+
 {{ with .Date }}
   <h5>{{ partial "docs/date" (dict "Date" . "Format" $.Site.Params.BookDateFormat) }}</h5>
 {{ end }}

--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -17,6 +17,7 @@ collections:
     fields:
       - { label: "Title", name: "title", widget: "string" }
       - { label: "Date", name: "date", widget: "date" }
+      - { label: "Authors", name: "authors", widget: "list", default: []}
       - { label: "Description", name: "description", widget: "string"}
       - { label: "Featured Image", name: "image", widget: "image", required: false}
       - { label: "Tags", name: "tags", widget: "list", default: ["news"]}


### PR DESCRIPTION
- Clean up some of the metadata fields on the blog posts.
- Add an author taxonomy, and specify the author info in the front matter instead of in the body of the blog post
- Add an author field to the CMS for editing a post

This allows us to style the `author` attribute separately in the view, have cleaner summaries, have author pages which show all posts by a give author. 
A future step could be to add author bios / photos for all authors.