### PR TITLE
Advertise RSS feed on main menu

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -11,6 +11,11 @@ theme = "book"
   url = "https://klezmerarchive.org"
   weight = 10
 
+[[menu.after]]
+  name = "RSS feed"
+  url = "posts/index.xml"
+  weight = 10
+
 [taxonomies]
 	author = "authors"
 	tag = "tags"


### PR DESCRIPTION
Adds a link in the menu to the auto-generated RSS feed for all posts.
Closes #20